### PR TITLE
Remove invalid chars from TestId.

### DIFF
--- a/src/TyrannosaurusTrx.TrxMerger/ReportModel/UnitTestResultReport.cs
+++ b/src/TyrannosaurusTrx.TrxMerger/ReportModel/UnitTestResultReport.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Web;
 using TRX_Merger.TrxModel;
 
 namespace TRX_Merger.ReportModel
@@ -91,7 +94,8 @@ namespace TRX_Merger.ReportModel
         {
             get
             {
-                return $"{ClassName.Replace(".", "")}_{Result.TestName.Replace(".", "")}";
+                var str =  $"{ClassName.Replace(".", "")}_{Result.TestName.Replace(".", "")}";
+                return Regex.Replace(str, "[^a-zA-Z0-9-_]", string.Empty);
             }
         }
 

--- a/src/TyrannosaurusTrx.TrxMerger/ReportModel/UnitTestResultReport.cs
+++ b/src/TyrannosaurusTrx.TrxMerger/ReportModel/UnitTestResultReport.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Web;
 using TRX_Merger.TrxModel;
 
 namespace TRX_Merger.ReportModel


### PR DESCRIPTION
Javascript function in the showTestDetails can't accept a parameter with special characters like brackets () []. This kind of IDs could be generated from parameterized testing reports.
See this pic:
![image](https://user-images.githubusercontent.com/13528118/116624467-f3863b80-a915-11eb-9ef7-1d486792790f.png)


