### PR TITLE
.Net 6.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ I've tested this on windows and linux with the example-tests folder.
  0.9.6 | Make github actions build and push tool
  1.0.0 | Added test, removed old code and merged in PR that fixed the skipped tests and completed label
  1.0.1 | Fixed bug relating to parameterised test names creating invalid chars for the HTML
+ 1.0.2 | Added .Net 6.0 Target

--- a/src/TyrannosaurusTrx.Tests/TyrannosaurusTrx.Tests.fsproj
+++ b/src/TyrannosaurusTrx.Tests/TyrannosaurusTrx.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/src/TyrannosaurusTrx/TyrannosaurusTrx.fsproj
+++ b/src/TyrannosaurusTrx/TyrannosaurusTrx.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t-trx</ToolCommandName>
     <PackageOutputPath>./out</PackageOutputPath>


### PR DESCRIPTION
```
/root/.dotnet/tools/t-trx -p /root/{obfuscated}/out/TestsResults.trx -r /root/{obfuscated}/out/TestsReport.html
non-zero return code
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '5.0.0' (x64) was not found.
  - The following frameworks were found:
      6.0.0 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=5.0.0&arch=x64&rid=debian.11-x64
```