### PR TITLE
1.2.0 | Added .Net 8.0 Target 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tyrannosaurus-trx
+0# tyrannosaurus-trx
 
 A trx file utility with most of the code copied from https://github.com/rndsolutions/trx-merger
 
@@ -82,3 +82,4 @@ I've tested this on windows and linux with the example-tests folder.
  1.0.1 | Fixed bug relating to parameterised test names creating invalid chars for the HTML
  1.0.2 | Added .Net 6.0 Target
  1.1.0 | Added .Net 7.0 Target and dropped support for 5 as MS no longer supports it
+ 1.2.0 | Added .Net 8.0 Target and dropped support for netcoreapp3.1 as MS no longer supports it (Ended Dec 13, 2022)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-0# tyrannosaurus-trx
+# tyrannosaurus-trx
 
 A trx file utility with most of the code copied from https://github.com/rndsolutions/trx-merger
 

--- a/src/TyrannosaurusTrx.Tests/TyrannosaurusTrx.Tests.fsproj
+++ b/src/TyrannosaurusTrx.Tests/TyrannosaurusTrx.Tests.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
@@ -15,30 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="InputFiles\MsTest_PassAndFail.trx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="InputFiles\NUnit_AllPass.trx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="InputFiles\NUnit_AllPass_SomeIgnored.trx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="InputFiles\NUnit_PassAndFail.trx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="InputFiles\XUnit_AllPass.trx">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="InputFiles\XUnit_PassAndFail.trx">
+    <None Include="InputFiles\**\*.trx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/TyrannosaurusTrx/TyrannosaurusTrx.fsproj
+++ b/src/TyrannosaurusTrx/TyrannosaurusTrx.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>t-trx</ToolCommandName>
     <PackageOutputPath>./out</PackageOutputPath>


### PR DESCRIPTION
Also dropped support for netcoreapp3.1 as MS no longer supports it (Ended Dec 13, 2022)